### PR TITLE
Support negative value. (Resolve #26)

### DIFF
--- a/examples/adt7410/main.js
+++ b/examples/adt7410/main.js
@@ -1,6 +1,5 @@
 import ADT7410 from "https://unpkg.com/@chirimen/adt7410?module";
 
-
 main();
 
 async function main() {
@@ -12,7 +11,7 @@ async function main() {
   for (;;) {
     // 無限ループ
     const value = await adt7410.read();
-    head.innerHTML = value ? `${value} degree` : "Measurement failure";
+    head.innerHTML = `${value} degree`;
     await sleep(1000);
   }
 }

--- a/node-examples/adt7410/main.js
+++ b/node-examples/adt7410/main.js
@@ -1,7 +1,7 @@
 const { requestI2CAccess } = require("node-web-i2c");
 const ADT7410 = require("@chirimen/adt7410");
 const { promisify } = require("util");
-const sleep = promisify(setTimeout)
+const sleep = promisify(setTimeout);
 
 main();
 
@@ -13,7 +13,7 @@ async function main() {
   for (;;) {
     // 無限ループ
     const value = await adt7410.read();
-    console.log(value ? `${value} degree` : "Measurement failure");
+    console.log(`${value} degree`);
     await sleep(1000);
   }
 }

--- a/packages/adt7410/adt7410.js
+++ b/packages/adt7410/adt7410.js
@@ -4,7 +4,7 @@
   (global = global || self, global.ADT7410 = factory());
 }(this, (function () { 'use strict';
 
-  var ADT7410 = function(i2cPort, slaveAddress) {
+  const ADT7410 = function(i2cPort, slaveAddress) {
     this.i2cPort = i2cPort;
     this.i2cSlave = null;
     this.slaveAddress = slaveAddress;
@@ -19,10 +19,16 @@
         throw new Error("i2cSlave is not open yet.");
       }
 
-      var MSB = await this.i2cSlave.read8(0x00);
-      var LSB = await this.i2cSlave.read8(0x01);
-      var data = ((MSB << 8) + LSB) / 128.0;
-      return data;
+      const MSB = await this.i2cSlave.read8(0x00);
+      const LSB = await this.i2cSlave.read8(0x01);
+      const rawData = ((MSB << 8) + LSB) >> 3;
+      if (MSB < 16) {
+        // Positive value
+        return rawData / 16.0;
+      } else {
+        // Negative value
+        return (rawData - 8192) / 16.0;
+      }
     }
   };
 

--- a/packages/adt7410/adt7410.mjs
+++ b/packages/adt7410/adt7410.mjs
@@ -16,7 +16,8 @@ ADT7410.prototype = {
     const MSB = await this.i2cSlave.read8(0x00);
     const LSB = await this.i2cSlave.read8(0x01);
     const rawData = ((MSB << 8) + LSB) >> 3;
-    if (MSB < 16) {
+    const sign = MSB & 0x10;
+    if (sign === 0) {
       // Positive value
       return rawData / 16.0;
     } else {

--- a/packages/adt7410/adt7410.mjs
+++ b/packages/adt7410/adt7410.mjs
@@ -15,7 +15,7 @@ ADT7410.prototype = {
 
     const MSB = await this.i2cSlave.read8(0x00);
     const LSB = await this.i2cSlave.read8(0x01);
-    const binaryTemperature = ((MSB << 8) + LSB) >> 3;
+    const binaryTemperature = ((MSB << 8) | LSB) >> 3;
     const sign = MSB & 0x10;
     // Under 13bit resolution mode. (sign + 12bit)
     if (sign === 0) {

--- a/packages/adt7410/adt7410.mjs
+++ b/packages/adt7410/adt7410.mjs
@@ -17,6 +17,7 @@ ADT7410.prototype = {
     const LSB = await this.i2cSlave.read8(0x01);
     const binaryTemperature = ((MSB << 8) + LSB) >> 3;
     const sign = MSB & 0x10;
+    // Under 13bit resolution mode. (sign + 12bit)
     if (sign === 0) {
       // Positive value
       return binaryTemperature / 16.0;

--- a/packages/adt7410/adt7410.mjs
+++ b/packages/adt7410/adt7410.mjs
@@ -1,4 +1,4 @@
-var ADT7410 = function(i2cPort, slaveAddress) {
+const ADT7410 = function(i2cPort, slaveAddress) {
   this.i2cPort = i2cPort;
   this.i2cSlave = null;
   this.slaveAddress = slaveAddress;
@@ -13,10 +13,16 @@ ADT7410.prototype = {
       throw new Error("i2cSlave is not open yet.");
     }
 
-    var MSB = await this.i2cSlave.read8(0x00);
-    var LSB = await this.i2cSlave.read8(0x01);
-    var data = ((MSB << 8) + LSB) / 128.0;
-    return data;
+    const MSB = await this.i2cSlave.read8(0x00);
+    const LSB = await this.i2cSlave.read8(0x01);
+    const rawData = ((MSB << 8) + LSB) >> 3;
+    if (MSB < 16) {
+      // Positive value
+      return rawData / 16.0;
+    } else {
+      // Negative value
+      return (rawData - 8192) / 16.0;
+    }
   }
 };
 

--- a/packages/adt7410/adt7410.mjs
+++ b/packages/adt7410/adt7410.mjs
@@ -15,14 +15,14 @@ ADT7410.prototype = {
 
     const MSB = await this.i2cSlave.read8(0x00);
     const LSB = await this.i2cSlave.read8(0x01);
-    const rawData = ((MSB << 8) + LSB) >> 3;
+    const binaryTemperature = ((MSB << 8) + LSB) >> 3;
     const sign = MSB & 0x10;
     if (sign === 0) {
       // Positive value
-      return rawData / 16.0;
+      return binaryTemperature / 16.0;
     } else {
       // Negative value
-      return (rawData - 8192) / 16.0;
+      return (binaryTemperature - 8192) / 16.0;
     }
   }
 };


### PR DESCRIPTION
# 変更点
## 1. 温度データのビット列の扱い方を修正
今まで、温度データが格納されているレジスタ0x00, 0x01のすべてのビットを温度データとして扱っていたが、[データシート](https://www.analog.com/media/en/technical-documentation/data-sheets/ADT7410.pdf)のP13, Table 9を参照すると、温度センサーの解像度が15bit(初期設定)に設定されているとき、下位３ビットはそれぞれT-LOW下回ったとき、T-HIGHを超えたとき、T-CRITに達したときに立つフラグであることが分かる。
なので、レジスタ0x01(LSB)の下位３ビットを温度データとして扱わないように変更した。

## 2. 負値の温度に対応
[データシート](https://www.analog.com/media/en/technical-documentation/data-sheets/ADT7410.pdf)のP12の解像度が15Bit時の計算式に倣って、負値の温度に対応した。


動作確認は正値の温度のみで、負値の温度については確認できていません。