### PR TITLE
fix adt7410

### DIFF
--- a/packages/adt7410/adt7410.js
+++ b/packages/adt7410/adt7410.js
@@ -16,8 +16,8 @@ ADT7410.prototype = {
     const MSB = await this.i2cSlave.read8(0x00);
     const LSB = await this.i2cSlave.read8(0x01);
     const binaryTemperature = ((MSB << 8) | LSB) >> 3;
-    const sign = MSB & 0x10;
     // Under 13bit resolution mode. (sign + 12bit)
+    const sign = binaryTemperature & 0x1000;
     if (sign === 0) {
       // Positive value
       return binaryTemperature / 16.0;

--- a/packages/adt7410/package.json
+++ b/packages/adt7410/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chirimen/adt7410",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Driver for ADT7410 with WebI2C",
   "main": "index.js",
   "module": "adt7410.js",

--- a/packages/tca9548a/package.json
+++ b/packages/tca9548a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chirimen/tca9548a",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Driver for TCA9548A with WebI2C",
   "author": "Kohei Watanabe <kou029w@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
- fix (adt7410): 32℃以上のときの値の異常/sign bit の位置の誤りの修正
- chore: bump version

 32 ℃くらいを越えると -479 ℃ などという温度になる現象の修正です

