### PR TITLE
GitHub Actionsの実行環境でUbuntu/Node.js Latest LTSを使う

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,12 @@ name: lint
 on: pull_request
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with: { node-version: 14 }
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "lts/*"
       - id: yarn_cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/*"
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
+          cache: yarn
       - run: yarn
       - run: yarn lint-report
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,12 @@ on:
     branches: ["master"]
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: "lts/*"
           registry-url: https://registry.npmjs.org/
       - id: yarn_cache
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/*"
+          cache: yarn
           registry-url: https://registry.npmjs.org/
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
       - run: yarn
       - name: Release
         run: |


### PR DESCRIPTION
GitHub Actionsの実行環境で[Ubuntu LTS (現在20.04)](https://docs.github.com/ja/actions/reference/workflow-syntax-for-github-actions#) が指定可能なので対応します。
加えて[actions/setup-node](https://github.com/actions/setup-node#readmehttps://github.com/actions/setup-node#readme)でlts/*を指定可能になったので対応します。
またactions/setup-nodeではcacheを指定可能になったので対応し、いままでのactions/cacheの対応を削除します。