### PR TITLE
add adt7410.init() at example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ import { requestI2CAccess, ADT7410 } from "chirimen";
 
 const i2cAccess = await requestI2CAccess();
 const adt7410 = new ADT7410(i2cAccess.ports.get(1), 0x48);
+await adt7410.init();
 await adt7410.read();
 ```
 


### PR DESCRIPTION
readme.md の usage / node.js のコードに `adt7410.init()` が抜けてたので追加しました。
