### PR TITLE
fix: fail ci for package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,10 @@
       "resolved": "packages/ltr390",
       "link": true
     },
+    "node_modules/@chirimen/mcp9808": {
+      "resolved": "packages/mcp9808",
+      "link": true
+    },
     "node_modules/@chirimen/microbit": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@chirimen/microbit/-/microbit-1.1.1.tgz",
@@ -171,6 +175,10 @@
     },
     "node_modules/@chirimen/mlx90614": {
       "resolved": "packages/mlx90614",
+      "link": true
+    },
+    "node_modules/@chirimen/mma7660": {
+      "resolved": "packages/mma7660",
       "link": true
     },
     "node_modules/@chirimen/mpu6050": {
@@ -9828,9 +9836,25 @@
         "rollup": "^4.0.0"
       }
     },
+    "packages/mcp9808": {
+      "name": "@chirimen/mcp9808",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "rollup": "^4.0.0"
+      }
+    },
     "packages/mlx90614": {
       "name": "@chirimen/mlx90614",
       "version": "1.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "rollup": "^4.0.0"
+      }
+    },
+    "packages/mma7660": {
+      "name": "@chirimen/mma7660",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "rollup": "^4.0.0"


### PR DESCRIPTION
#381, #382 での　package-lock.json 欠落を修正する PR