### PR TITLE
Grove 水位センサーのドライバを追加

### DIFF
--- a/packages/grove-water-level-sensor/.gitignore
+++ b/packages/grove-water-level-sensor/.gitignore
@@ -1,0 +1,1 @@
+/index.js

--- a/packages/grove-water-level-sensor/grove-water-level-sensor.js
+++ b/packages/grove-water-level-sensor/grove-water-level-sensor.js
@@ -1,0 +1,74 @@
+// @ts-check
+// grove-water-level-sensor driver for CHIRIMEN
+// Based from https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino
+// Programmed by Masahito Inoue
+
+const THRESHOLD = 100;
+
+class WaterLevelSensor {
+  // Since the addresses at the top and bottom of the sensor are different, initialize each address separately.
+  constructor(i2cPort, slaveAddressLow, slaveAddressHigh) {
+    this.i2cPort = i2cPort;
+    this.i2cSlaveLow = null;
+    this.i2cSlaveHigh = null;
+    this.slaveAddressLow = slaveAddressLow;
+    this.slaveAddressHigh = slaveAddressHigh;
+  }
+
+  async init() {
+    this.i2cSlaveLow = await this.i2cPort.open(this.slaveAddressLow);
+    this.i2cSlaveHigh = await this.i2cPort.open(this.slaveAddressHigh);
+  }
+
+  async getHigh12SectionValue() {
+    if (this.i2cSlaveHigh == null) {
+      throw new Error("i2cSlaveHigh is not open yet.");
+    }
+
+    const high12SectionValue = await this.i2cSlaveHigh.readBytes(12);
+
+    return high12SectionValue;
+  }
+
+  async getLow8SectionValue() {
+    if (this.i2cSlaveLow == null) {
+      throw new Error("i2cSlaveLow is not open yet.");
+    }
+
+    const low8SectionValue = await this.i2cSlaveLow.readBytes(8);
+
+    return low8SectionValue;
+  }
+
+  async getWaterLevel() {
+    const high_data = await this.getHigh12SectionValue();
+    const low_data = await this.getLow8SectionValue();
+    let touch_val = 0;
+    let trig_section = 0;
+
+    for (let i = 0 ; i < 8; i++) {
+      if (low_data[i] > THRESHOLD) {
+        touch_val |= 1 << i;
+      }
+    }
+    for (let i = 0 ; i < 12; i++) {
+      if (high_data[i] > THRESHOLD) {
+        touch_val |= 1 << (8 + i);
+      }
+    }
+
+    // Check if the least significant bit is 1.
+    while (touch_val & 0x01)
+    {
+      trig_section++;
+      touch_val >>= 1;
+    }
+
+    // Since there are 20 sensor sections, multiply by 5 to convert to a percentage.
+    const value = trig_section * 5;
+
+    return value;
+  }
+}
+
+export default WaterLevelSensor;

--- a/packages/grove-water-level-sensor/package.json
+++ b/packages/grove-water-level-sensor/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@chirimen/grove-water-level-sensor",
+  "version": "1.0.0",
+  "description": "Driver for grove-water-level-sensor with WebI2C",
+  "main": "index.js",
+  "module": "grove-water-level-sensor.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chirimen-oh/chirimen-drivers.git",
+    "directory": "packages/grove-water-level-sensor"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rollup -c --bundleConfigAsCjs",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "rollup": "^4.0.0"
+  }
+}

--- a/packages/grove-water-level-sensor/rollup.config.js
+++ b/packages/grove-water-level-sensor/rollup.config.js
@@ -1,0 +1,10 @@
+import { module as input, main as outputFile } from "./package.json";
+
+export default {
+  input,
+  output: {
+    file: outputFile,
+    format: "umd",
+    name: "grove-water-level-sensor"
+  }
+};


### PR DESCRIPTION
Groveの水位センサーのドライバを追加いたしました。
製品ページ：https://www.switch-science.com/products/6282

参考にしたコードは下記になります。
https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino

最大10センチの範囲で水位を5%毎の割合で出力できるようにしております。
このドライバに対応するexampleは後日追加いたします。

お手数をおかけしますが、ご確認よろしくお願いいたします。