### PR TITLE
fix(CI): add package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,6 +209,10 @@
       "resolved": "packages/pcf8591",
       "link": true
     },
+    "node_modules/@chirimen/qrcodescanner": {
+      "resolved": "packages/qrcodescanner",
+      "link": true
+    },
     "node_modules/@chirimen/s11059": {
       "resolved": "packages/s11059",
       "link": true
@@ -9878,6 +9882,14 @@
     "packages/pcf8591": {
       "name": "@chirimen/pcf8591",
       "version": "1.0.3",
+      "license": "MIT",
+      "devDependencies": {
+        "rollup": "^4.0.0"
+      }
+    },
+    "packages/qrcodescanner": {
+      "name": "@chirimen/qrcodescanner",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "rollup": "^4.0.0"


### PR DESCRIPTION
- #399 で、不足した package-lick.json の追加
- [CI 失敗の対応](https://github.com/chirimen-oh/chirimen-drivers/actions/runs/17188916842/job/48761801532)

マージされると `@chirimen/qrcodescanner` が登録される見込みです。