### PR TITLE
Include mermaid script in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,12 @@ flowchart TD
 PR が master にマージされると、GitHub Actions が自動的に npm へパッケージを公開します。手動でリリース作業を行う必要はありません。
 
 バージョン管理の仕組みやメンテナ向けの詳細は [リリース方法](docs/contributing/release.md) を参照してください。
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+  mermaid.initialize({ startOnLoad: false });
+  await mermaid.run({
+    querySelector: '.language-mermaid',
+  });
+</script>


### PR DESCRIPTION
This pull request adds support for rendering Mermaid diagrams directly within the `CONTRIBUTING.md` documentation by including a script to load and initialize Mermaid.js.

Documentation improvements:

* Added a `<script>` block to `CONTRIBUTING.md` that imports Mermaid.js from a CDN and initializes it to render diagrams for elements with the `.language-mermaid` class.Add mermaid script for diagram rendering in documentation.