### PR TITLE
Change Git user configuration for release bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       - run: npm ci
       - name: Git Setup
         run: |
-          git config user.name release[bot]
-          git config user.email "release[bot]@users.noreply.github.com"
+          git config user.name github-actions[bot]
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Update README Download Section
         run: |
           chmod +x update-readme-download.sh


### PR DESCRIPTION
This pull request updates the Git configuration for release automation to use the standardized GitHub Actions bot identity instead of a custom release bot. This ensures consistency and proper attribution for automated commits.

Workflow configuration update:

* Changed the Git user name and email in the `.github/workflows/release.yml` workflow from `release[bot]` to `github-actions[bot]`, aligning with GitHub's recommended automation practices.