### PR TITLE
Add DRV2605L driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,10 @@
       "resolved": "packages/ccs811",
       "link": true
     },
+    "node_modules/@chirimen/drv2605l": {
+      "resolved": "packages/drv2605l",
+      "link": true
+    },
     "node_modules/@chirimen/ens160": {
       "resolved": "packages/ens160",
       "link": true
@@ -7311,6 +7315,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@chirimen/vl6180x/-/vl6180x-2.0.0.tgz",
       "integrity": "sha512-8sZzM1ox0OVUcvsXQIelEgUpuyhve/akIAsrViNEHBXtMt3f7Ib6y8m7s4XA9YeIa3VJQg1a5Mxba1aG6IEKpQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-web-i2c": "^1.1.51"
+      }
+    },
+    "packages/drv2605l": {
+      "name": "@chirimen/drv2605l",
+      "version": "1.0.0",
       "license": "MIT",
       "peerDependencies": {
         "node-web-i2c": "^1.1.51"

--- a/packages/drv2605l/README.md
+++ b/packages/drv2605l/README.md
@@ -32,8 +32,8 @@ const motor = new DRV2605L(i2cPort, 0x5a);
 
 await motor.init();
 
-// 強度80で400ミリ秒振動
-await motor.vibrate(80, 400);
+// 強度100で200ミリ秒振動
+await motor.vibrate(100, 200);
 ```
 
 ## API
@@ -55,7 +55,7 @@ ERM用エフェクトライブラリを選択し、ERMオープンループ動�
 
 DRV2605Lに内蔵されている波形エフェクトを再生します。
 
-- `effect`: エフェクト番号。`1`〜`123`
+- `effect`: エフェクト番号を`1`〜`123`の整数で指定します。デフォルト値は `1` です。
 
 例:
 
@@ -67,13 +67,13 @@ await motor.playEffect(1);
 
 Real-Time Playback（RTP）モードを使用して振動モーターを動作させます。
 
-- `strength`: 振動強度。`0`〜`127`
-- `duration`: 振動時間。ミリ秒単位
+- `strength`: 振動強度を `0`〜`127` の整数で指定します。デフォルト値は `100` です。
+- `duration`: 振動時間を0以上の整数でミリ秒単位で指定します。デフォルト値は `200` です。
 
 例:
 
 ```js
-await motor.vibrate(80, 400);
+await motor.vibrate(100, 200);
 ```
 
 ### `stop()`

--- a/packages/drv2605l/README.md
+++ b/packages/drv2605l/README.md
@@ -1,25 +1,25 @@
 # DRV2605L
 
-DRV2605L is a haptic motor driver controlled via I2C.
+DRV2605Lは、I2Cで制御するハプティックモータードライバーです。
 
-This CHIRIMEN driver supports ERM vibration motors and provides built-in waveform playback and Real-Time Playback (RTP) vibration control.
+このCHIRIMENドライバーはERM振動モーターに対応し、内蔵波形エフェクトの再生とReal-Time Playback（RTP）モードによる振動制御を行えます。
 
-## Specifications
+## 仕様
 
-- Device: DRV2605L
-- Interface: I2C
-- Default I2C address: `0x5A`
-- Supported motor type: ERM
-- Built-in waveform effects: 1–123
-- RTP vibration strength: 0–127
+- デバイス: DRV2605L
+- インターフェイス: I2C
+- デフォルトI2Cアドレス: `0x5A`
+- 対応モーター: ERM
+- 内蔵波形エフェクト: 1〜123
+- RTP振動強度: 0〜127
 
-## Installation
+## インストール
 
 ```bash
 npm install @chirimen/drv2605l
 ```
 
-## Usage
+## 使用方法
 
 ```js
 import { requestI2CAccess } from "node-web-i2c";
@@ -32,7 +32,7 @@ const motor = new DRV2605L(i2cPort, 0x5a);
 
 await motor.init();
 
-// Vibrate with strength 80 for 400 ms
+// 強度80で400ミリ秒振動
 await motor.vibrate(80, 400);
 ```
 
@@ -40,24 +40,24 @@ await motor.vibrate(80, 400);
 
 ### `constructor(i2cPort, slaveAddress)`
 
-Creates a DRV2605L driver instance.
+DRV2605Lドライバーのインスタンスを生成します。
 
-- `i2cPort`: I2C port instance
-- `slaveAddress`: I2C slave address. Defaults to `0x5A`
+- `i2cPort`: I2Cポートのインスタンス
+- `slaveAddress`: I2Cスレーブアドレス。省略時は `0x5A`
 
 ### `init()`
 
-Initializes the DRV2605L for an ERM vibration motor.
+DRV2605LをERM振動モーター用に初期化します。
 
-The driver uses the ERM effect library and configures the device for open-loop ERM operation.
+ERM用エフェクトライブラリを選択し、ERMオープンループ動作用に設定します。
 
 ### `playEffect(effect = 1)`
 
-Plays one of the DRV2605L built-in waveform effects.
+DRV2605Lに内蔵されている波形エフェクトを再生します。
 
-- `effect`: Effect number from `1` to `123`
+- `effect`: エフェクト番号。`1`〜`123`
 
-Example:
+例:
 
 ```js
 await motor.playEffect(1);
@@ -65,12 +65,12 @@ await motor.playEffect(1);
 
 ### `vibrate(strength = 100, duration = 200)`
 
-Vibrates the motor using Real-Time Playback (RTP) mode.
+Real-Time Playback（RTP）モードを使用して振動モーターを動作させます。
 
-- `strength`: Vibration strength from `0` to `127`
-- `duration`: Duration in milliseconds
+- `strength`: 振動強度。`0`〜`127`
+- `duration`: 振動時間。ミリ秒単位
 
-Example:
+例:
 
 ```js
 await motor.vibrate(80, 400);
@@ -78,16 +78,16 @@ await motor.vibrate(80, 400);
 
 ### `stop()`
 
-Stops waveform playback and RTP vibration.
+波形エフェクトの再生およびRTP振動を停止します。
 
-Example:
+例:
 
 ```js
 await motor.stop();
 ```
 
-## Datasheet
+## データシート
 
-Texas Instruments DRV2605L product page:
+Texas Instruments DRV2605L:
 
 https://www.ti.com/product/DRV2605L

--- a/packages/drv2605l/README.md
+++ b/packages/drv2605l/README.md
@@ -1,0 +1,93 @@
+# DRV2605L
+
+DRV2605L is a haptic motor driver controlled via I2C.
+
+This CHIRIMEN driver supports ERM vibration motors and provides built-in waveform playback and Real-Time Playback (RTP) vibration control.
+
+## Specifications
+
+- Device: DRV2605L
+- Interface: I2C
+- Default I2C address: `0x5A`
+- Supported motor type: ERM
+- Built-in waveform effects: 1–123
+- RTP vibration strength: 0–127
+
+## Installation
+
+```bash
+npm install @chirimen/drv2605l
+```
+
+## Usage
+
+```js
+import { requestI2CAccess } from "node-web-i2c";
+import DRV2605L from "@chirimen/drv2605l";
+
+const i2cAccess = await requestI2CAccess();
+const i2cPort = i2cAccess.ports.get(1);
+
+const motor = new DRV2605L(i2cPort, 0x5a);
+
+await motor.init();
+
+// Vibrate with strength 80 for 400 ms
+await motor.vibrate(80, 400);
+```
+
+## API
+
+### `constructor(i2cPort, slaveAddress)`
+
+Creates a DRV2605L driver instance.
+
+- `i2cPort`: I2C port instance
+- `slaveAddress`: I2C slave address. Defaults to `0x5A`
+
+### `init()`
+
+Initializes the DRV2605L for an ERM vibration motor.
+
+The driver uses the ERM effect library and configures the device for open-loop ERM operation.
+
+### `playEffect(effect = 1)`
+
+Plays one of the DRV2605L built-in waveform effects.
+
+- `effect`: Effect number from `1` to `123`
+
+Example:
+
+```js
+await motor.playEffect(1);
+```
+
+### `vibrate(strength = 100, duration = 200)`
+
+Vibrates the motor using Real-Time Playback (RTP) mode.
+
+- `strength`: Vibration strength from `0` to `127`
+- `duration`: Duration in milliseconds
+
+Example:
+
+```js
+await motor.vibrate(80, 400);
+```
+
+### `stop()`
+
+Stops waveform playback and RTP vibration.
+
+Example:
+
+```js
+await motor.stop();
+```
+
+## Datasheet
+
+Texas Instruments DRV2605L product page:
+
+https://www.ti.com/product/DRV2605L

--- a/packages/drv2605l/README.md
+++ b/packages/drv2605l/README.md
@@ -90,4 +90,4 @@ await motor.stop();
 
 Texas Instruments DRV2605L:
 
-https://www.ti.com/product/DRV2605L
+https://www.ti.com/lit/ds/symlink/drv2605l.pdf

--- a/packages/drv2605l/README.md
+++ b/packages/drv2605l/README.md
@@ -10,6 +10,7 @@ DRV2605Lは、I2Cで制御するハプティックモータードライバーで
 - インターフェイス: I2C
 - デフォルトI2Cアドレス: `0x5A`
 - 対応モーター: ERM
+- デフォルトOverdrive Clamp値: `0x8C`（約3.02V）
 - 内蔵波形エフェクト: 1〜123
 - RTP振動強度: 0〜127
 
@@ -38,12 +39,13 @@ await motor.vibrate(100, 200);
 
 ## API
 
-### `constructor(i2cPort, slaveAddress)`
+### `constructor(i2cPort, slaveAddress, overdriveClamp)`
 
 DRV2605Lドライバーのインスタンスを生成します。
 
 - `i2cPort`: I2Cポートのインスタンス
 - `slaveAddress`: I2Cスレーブアドレス。省略時は `0x5A`
+- `overdriveClamp`: ERMオープンループ動作時のOverdrive Clampレジスタ値を `0`〜`255` の整数で指定します。省略時は `0x8C`（約3.02V）です。使用するモーターの定格電圧に合わせて設定してください。
 
 ### `init()`
 

--- a/packages/drv2605l/index.js
+++ b/packages/drv2605l/index.js
@@ -53,85 +53,43 @@ class DRV2605L {
     this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
 
     // Internal trigger mode
-    await this.i2cSlave.write8(
-      REG_MODE,
-      MODE_INTERNAL_TRIGGER
-    );
+    await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
 
     // Disable RTP input
-    await this.i2cSlave.write8(
-      REG_RTP_INPUT,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_RTP_INPUT, 0x00);
 
     // Select ERM effect library
-    await this.i2cSlave.write8(
-      REG_LIBRARY,
-      LIBRARY_ERM_A
-    );
+    await this.i2cSlave.write8(REG_LIBRARY, LIBRARY_ERM_A);
 
     // Clear waveform sequence
-    await this.i2cSlave.write8(
-      REG_WAVESEQ1,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_WAVESEQ1, 0x00);
 
-    await this.i2cSlave.write8(
-      REG_WAVESEQ2,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_WAVESEQ2, 0x00);
 
     // Reset timing offsets
-    await this.i2cSlave.write8(
-      REG_OVERDRIVE_TIME_OFFSET,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_OVERDRIVE_TIME_OFFSET, 0x00);
 
-    await this.i2cSlave.write8(
-      REG_SUSTAIN_TIME_OFFSET_POS,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_SUSTAIN_TIME_OFFSET_POS, 0x00);
 
-    await this.i2cSlave.write8(
-      REG_SUSTAIN_TIME_OFFSET_NEG,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_SUSTAIN_TIME_OFFSET_NEG, 0x00);
 
-    await this.i2cSlave.write8(
-      REG_BRAKE_TIME_OFFSET,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_BRAKE_TIME_OFFSET, 0x00);
 
-    await this.i2cSlave.write8(
-      REG_AUDIO_MAX_INPUT,
-      0x64
-    );
+    await this.i2cSlave.write8(REG_AUDIO_MAX_INPUT, 0x64);
 
     // Select ERM mode
-    let feedback =
-      await this.i2cSlave.read8(
-        REG_FEEDBACK_CONTROL
-      );
+    let feedback = await this.i2cSlave.read8(REG_FEEDBACK_CONTROL);
 
     feedback &= 0x7f;
 
-    await this.i2cSlave.write8(
-      REG_FEEDBACK_CONTROL,
-      feedback
-    );
+    await this.i2cSlave.write8(REG_FEEDBACK_CONTROL, feedback);
 
     // ERM open-loop mode
-    let control3 =
-      await this.i2cSlave.read8(
-        REG_CONTROL3
-      );
+    let control3 = await this.i2cSlave.read8(REG_CONTROL3);
 
     control3 |= 0x20;
 
-    await this.i2cSlave.write8(
-      REG_CONTROL3,
-      control3
-    );
+    await this.i2cSlave.write8(REG_CONTROL3, control3);
 
     console.log("DRV2605L initialized");
   }
@@ -143,44 +101,24 @@ class DRV2605L {
    */
   async playEffect(effect = 1) {
     if (!this.i2cSlave) {
-      throw new Error(
-        "DRV2605L is not initialized"
-      );
+      throw new Error("DRV2605L is not initialized");
     }
 
-    if (
-      !Number.isInteger(effect) ||
-      effect < 1 ||
-      effect > 123
-    ) {
-      throw new RangeError(
-        "effect must be an integer from 1 to 123"
-      );
+    if (!Number.isInteger(effect) || effect < 1 || effect > 123) {
+      throw new RangeError("effect must be an integer from 1 to 123");
     }
 
     // Return to internal trigger mode
-    await this.i2cSlave.write8(
-      REG_MODE,
-      MODE_INTERNAL_TRIGGER
-    );
+    await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
 
     // Select effect
-    await this.i2cSlave.write8(
-      REG_WAVESEQ1,
-      effect
-    );
+    await this.i2cSlave.write8(REG_WAVESEQ1, effect);
 
     // End waveform sequence
-    await this.i2cSlave.write8(
-      REG_WAVESEQ2,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_WAVESEQ2, 0x00);
 
     // Start playback
-    await this.i2cSlave.write8(
-      REG_GO,
-      GO
-    );
+    await this.i2cSlave.write8(REG_GO, GO);
   }
 
   /**
@@ -191,58 +129,31 @@ class DRV2605L {
    */
   async vibrate(strength = 100, duration = 200) {
     if (!this.i2cSlave) {
-      throw new Error(
-        "DRV2605L is not initialized"
-      );
+      throw new Error("DRV2605L is not initialized");
     }
 
-    if (
-      !Number.isInteger(strength) ||
-      strength < 0 ||
-      strength > 127
-    ) {
-      throw new RangeError(
-        "strength must be an integer from 0 to 127"
-      );
+    if (!Number.isInteger(strength) || strength < 0 || strength > 127) {
+      throw new RangeError("strength must be an integer from 0 to 127");
     }
 
-    if (
-      !Number.isInteger(duration) ||
-      duration < 0
-    ) {
-      throw new RangeError(
-        "duration must be a positive integer"
-      );
+    if (!Number.isInteger(duration) || duration < 0) {
+      throw new RangeError("duration must be a positive integer");
     }
 
     // Change to Real-Time Playback mode
-    await this.i2cSlave.write8(
-      REG_MODE,
-      MODE_REAL_TIME_PLAYBACK
-    );
+    await this.i2cSlave.write8(REG_MODE, MODE_REAL_TIME_PLAYBACK);
 
     // Start vibration
-    await this.i2cSlave.write8(
-      REG_RTP_INPUT,
-      strength
-    );
+    await this.i2cSlave.write8(REG_RTP_INPUT, strength);
 
     // Keep vibrating for the specified duration
-    await new Promise((resolve) =>
-      setTimeout(resolve, duration)
-    );
+    await new Promise((resolve) => setTimeout(resolve, duration));
 
     // Stop vibration
-    await this.i2cSlave.write8(
-      REG_RTP_INPUT,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_RTP_INPUT, 0x00);
 
     // Return to internal trigger mode
-    await this.i2cSlave.write8(
-      REG_MODE,
-      MODE_INTERNAL_TRIGGER
-    );
+    await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
   }
 
   /**
@@ -250,28 +161,17 @@ class DRV2605L {
    */
   async stop() {
     if (!this.i2cSlave) {
-      throw new Error(
-        "DRV2605L is not initialized"
-      );
+      throw new Error("DRV2605L is not initialized");
     }
 
     // Stop waveform playback
-    await this.i2cSlave.write8(
-      REG_GO,
-      STOP
-    );
+    await this.i2cSlave.write8(REG_GO, STOP);
 
     // Stop RTP vibration
-    await this.i2cSlave.write8(
-      REG_RTP_INPUT,
-      0x00
-    );
+    await this.i2cSlave.write8(REG_RTP_INPUT, 0x00);
 
     // Return to internal trigger mode
-    await this.i2cSlave.write8(
-      REG_MODE,
-      MODE_INTERNAL_TRIGGER
-    );
+    await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
   }
 }
 

--- a/packages/drv2605l/index.js
+++ b/packages/drv2605l/index.js
@@ -17,7 +17,6 @@ const REG_OVERDRIVE_TIME_OFFSET = 0x0d;
 const REG_SUSTAIN_TIME_OFFSET_POS = 0x0e;
 const REG_SUSTAIN_TIME_OFFSET_NEG = 0x0f;
 const REG_BRAKE_TIME_OFFSET = 0x10;
-const REG_AUDIO_MAX_INPUT = 0x13;
 const REG_OVERDRIVE_CLAMP = 0x17;
 const REG_FEEDBACK_CONTROL = 0x1a;
 const REG_CONTROL3 = 0x1d;
@@ -81,8 +80,6 @@ class DRV2605L {
 
     await this.i2cSlave.write8(REG_BRAKE_TIME_OFFSET, 0x00);
 
-    await this.i2cSlave.write8(REG_AUDIO_MAX_INPUT, 0x64);
-
     // Set the full-scale voltage reference for ERM open-loop operation.
     // 0x8C corresponds to approximately 3.02 V.
     await this.i2cSlave.write8(REG_OVERDRIVE_CLAMP, DEFAULT_OVERDRIVE_CLAMP);
@@ -100,8 +97,6 @@ class DRV2605L {
     control3 |= 0x20;
 
     await this.i2cSlave.write8(REG_CONTROL3, control3);
-
-    console.log("DRV2605L initialized");
   }
 
   /**

--- a/packages/drv2605l/index.js
+++ b/packages/drv2605l/index.js
@@ -1,0 +1,278 @@
+// @ts-check
+
+// DRV2605L driver for CHIRIMEN
+// Haptic Motor Driver
+
+const DEFAULT_SLAVE_ADDRESS = 0x5a;
+
+// DRV2605L registers
+const REG_MODE = 0x01;
+const REG_RTP_INPUT = 0x02;
+const REG_LIBRARY = 0x03;
+const REG_WAVESEQ1 = 0x04;
+const REG_WAVESEQ2 = 0x05;
+const REG_GO = 0x0c;
+const REG_OVERDRIVE_TIME_OFFSET = 0x0d;
+const REG_SUSTAIN_TIME_OFFSET_POS = 0x0e;
+const REG_SUSTAIN_TIME_OFFSET_NEG = 0x0f;
+const REG_BRAKE_TIME_OFFSET = 0x10;
+const REG_AUDIO_MAX_INPUT = 0x13;
+const REG_FEEDBACK_CONTROL = 0x1a;
+const REG_CONTROL3 = 0x1d;
+
+// Operation modes
+const MODE_INTERNAL_TRIGGER = 0x00;
+const MODE_REAL_TIME_PLAYBACK = 0x05;
+
+// ERM effect library
+const LIBRARY_ERM_A = 0x01;
+
+const GO = 0x01;
+const STOP = 0x00;
+
+class DRV2605L {
+  /**
+   * @constructor
+   * @param {import('node-web-i2c').I2CPort} i2cPort I2C port instance
+   * @param {number?} slaveAddress I2C slave address
+   */
+  constructor(i2cPort, slaveAddress) {
+    if (!slaveAddress) {
+      slaveAddress = DEFAULT_SLAVE_ADDRESS;
+    }
+
+    this.i2cPort = i2cPort;
+    this.i2cSlave = null;
+    this.slaveAddress = slaveAddress;
+  }
+
+  /**
+   * Initialize DRV2605L for an ERM vibration motor.
+   */
+  async init() {
+    this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
+
+    // Internal trigger mode
+    await this.i2cSlave.write8(
+      REG_MODE,
+      MODE_INTERNAL_TRIGGER
+    );
+
+    // Disable RTP input
+    await this.i2cSlave.write8(
+      REG_RTP_INPUT,
+      0x00
+    );
+
+    // Select ERM effect library
+    await this.i2cSlave.write8(
+      REG_LIBRARY,
+      LIBRARY_ERM_A
+    );
+
+    // Clear waveform sequence
+    await this.i2cSlave.write8(
+      REG_WAVESEQ1,
+      0x00
+    );
+
+    await this.i2cSlave.write8(
+      REG_WAVESEQ2,
+      0x00
+    );
+
+    // Reset timing offsets
+    await this.i2cSlave.write8(
+      REG_OVERDRIVE_TIME_OFFSET,
+      0x00
+    );
+
+    await this.i2cSlave.write8(
+      REG_SUSTAIN_TIME_OFFSET_POS,
+      0x00
+    );
+
+    await this.i2cSlave.write8(
+      REG_SUSTAIN_TIME_OFFSET_NEG,
+      0x00
+    );
+
+    await this.i2cSlave.write8(
+      REG_BRAKE_TIME_OFFSET,
+      0x00
+    );
+
+    await this.i2cSlave.write8(
+      REG_AUDIO_MAX_INPUT,
+      0x64
+    );
+
+    // Select ERM mode
+    let feedback =
+      await this.i2cSlave.read8(
+        REG_FEEDBACK_CONTROL
+      );
+
+    feedback &= 0x7f;
+
+    await this.i2cSlave.write8(
+      REG_FEEDBACK_CONTROL,
+      feedback
+    );
+
+    // ERM open-loop mode
+    let control3 =
+      await this.i2cSlave.read8(
+        REG_CONTROL3
+      );
+
+    control3 |= 0x20;
+
+    await this.i2cSlave.write8(
+      REG_CONTROL3,
+      control3
+    );
+
+    console.log("DRV2605L initialized");
+  }
+
+  /**
+   * Play a built-in waveform effect.
+   *
+   * @param {number} effect Effect number (1-123)
+   */
+  async playEffect(effect = 1) {
+    if (!this.i2cSlave) {
+      throw new Error(
+        "DRV2605L is not initialized"
+      );
+    }
+
+    if (
+      !Number.isInteger(effect) ||
+      effect < 1 ||
+      effect > 123
+    ) {
+      throw new RangeError(
+        "effect must be an integer from 1 to 123"
+      );
+    }
+
+    // Return to internal trigger mode
+    await this.i2cSlave.write8(
+      REG_MODE,
+      MODE_INTERNAL_TRIGGER
+    );
+
+    // Select effect
+    await this.i2cSlave.write8(
+      REG_WAVESEQ1,
+      effect
+    );
+
+    // End waveform sequence
+    await this.i2cSlave.write8(
+      REG_WAVESEQ2,
+      0x00
+    );
+
+    // Start playback
+    await this.i2cSlave.write8(
+      REG_GO,
+      GO
+    );
+  }
+
+  /**
+   * Vibrate using Real-Time Playback mode.
+   *
+   * @param {number} strength Vibration strength (0-127)
+   * @param {number} duration Duration in milliseconds
+   */
+  async vibrate(strength = 100, duration = 200) {
+    if (!this.i2cSlave) {
+      throw new Error(
+        "DRV2605L is not initialized"
+      );
+    }
+
+    if (
+      !Number.isInteger(strength) ||
+      strength < 0 ||
+      strength > 127
+    ) {
+      throw new RangeError(
+        "strength must be an integer from 0 to 127"
+      );
+    }
+
+    if (
+      !Number.isInteger(duration) ||
+      duration < 0
+    ) {
+      throw new RangeError(
+        "duration must be a positive integer"
+      );
+    }
+
+    // Change to Real-Time Playback mode
+    await this.i2cSlave.write8(
+      REG_MODE,
+      MODE_REAL_TIME_PLAYBACK
+    );
+
+    // Start vibration
+    await this.i2cSlave.write8(
+      REG_RTP_INPUT,
+      strength
+    );
+
+    // Keep vibrating for the specified duration
+    await new Promise((resolve) =>
+      setTimeout(resolve, duration)
+    );
+
+    // Stop vibration
+    await this.i2cSlave.write8(
+      REG_RTP_INPUT,
+      0x00
+    );
+
+    // Return to internal trigger mode
+    await this.i2cSlave.write8(
+      REG_MODE,
+      MODE_INTERNAL_TRIGGER
+    );
+  }
+
+  /**
+   * Stop vibration.
+   */
+  async stop() {
+    if (!this.i2cSlave) {
+      throw new Error(
+        "DRV2605L is not initialized"
+      );
+    }
+
+    // Stop waveform playback
+    await this.i2cSlave.write8(
+      REG_GO,
+      STOP
+    );
+
+    // Stop RTP vibration
+    await this.i2cSlave.write8(
+      REG_RTP_INPUT,
+      0x00
+    );
+
+    // Return to internal trigger mode
+    await this.i2cSlave.write8(
+      REG_MODE,
+      MODE_INTERNAL_TRIGGER
+    );
+  }
+}
+
+export default DRV2605L;

--- a/packages/drv2605l/index.js
+++ b/packages/drv2605l/index.js
@@ -36,16 +36,31 @@ class DRV2605L {
    * @constructor
    * @param {import('node-web-i2c').I2CPort} i2cPort I2C port instance
    * @param {number} [slaveAddress] I2C slave address
+   * @param {number} [overdriveClamp] Overdrive clamp register value (0-255)
    */
-  constructor(i2cPort, slaveAddress) {
+  constructor(i2cPort, slaveAddress, overdriveClamp) {
     if (slaveAddress === undefined) {
       slaveAddress = DEFAULT_SLAVE_ADDRESS;
+    }
+
+    if (overdriveClamp === undefined) {
+      overdriveClamp = DEFAULT_OVERDRIVE_CLAMP;
+    }
+
+    if (
+      !Number.isInteger(overdriveClamp) ||
+      overdriveClamp < 0 ||
+      overdriveClamp > 255
+    ) {
+      throw new RangeError("overdriveClamp must be an integer from 0 to 255");
     }
 
     this.i2cPort = i2cPort;
     this.i2cSlave = null;
     this.slaveAddress = slaveAddress;
+    this.overdriveClamp = overdriveClamp;
     this.operationId = 0;
+    this.initPromise = null;
   }
 
   /**
@@ -55,48 +70,59 @@ class DRV2605L {
     if (this.i2cSlave) {
       return;
     }
-    this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
 
-    // Internal trigger mode
-    await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
+    if (this.initPromise) {
+      await this.initPromise;
+      return;
+    }
 
-    // Disable RTP input
-    await this.i2cSlave.write8(REG_RTP_INPUT, 0x00);
+    this.initPromise = (async () => {
+      try {
+        this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
 
-    // Select ERM effect library
-    await this.i2cSlave.write8(REG_LIBRARY, LIBRARY_ERM_A);
+        // Internal trigger mode
+        await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
 
-    // Clear waveform sequence
-    await this.i2cSlave.write8(REG_WAVESEQ1, 0x00);
+        // Disable RTP input
+        await this.i2cSlave.write8(REG_RTP_INPUT, 0x00);
 
-    await this.i2cSlave.write8(REG_WAVESEQ2, 0x00);
+        // Select ERM effect library
+        await this.i2cSlave.write8(REG_LIBRARY, LIBRARY_ERM_A);
 
-    // Reset timing offsets
-    await this.i2cSlave.write8(REG_OVERDRIVE_TIME_OFFSET, 0x00);
+        // Clear waveform sequence
+        await this.i2cSlave.write8(REG_WAVESEQ1, 0x00);
+        await this.i2cSlave.write8(REG_WAVESEQ2, 0x00);
 
-    await this.i2cSlave.write8(REG_SUSTAIN_TIME_OFFSET_POS, 0x00);
+        // Reset timing offsets
+        await this.i2cSlave.write8(REG_OVERDRIVE_TIME_OFFSET, 0x00);
+        await this.i2cSlave.write8(REG_SUSTAIN_TIME_OFFSET_POS, 0x00);
+        await this.i2cSlave.write8(REG_SUSTAIN_TIME_OFFSET_NEG, 0x00);
+        await this.i2cSlave.write8(REG_BRAKE_TIME_OFFSET, 0x00);
 
-    await this.i2cSlave.write8(REG_SUSTAIN_TIME_OFFSET_NEG, 0x00);
+        // Set the full-scale voltage reference for ERM open-loop operation.
+        // The default value 0x8C corresponds to approximately 3.02 V.
+        await this.i2cSlave.write8(REG_OVERDRIVE_CLAMP, this.overdriveClamp);
 
-    await this.i2cSlave.write8(REG_BRAKE_TIME_OFFSET, 0x00);
+        // Select ERM mode
+        let feedback = await this.i2cSlave.read8(REG_FEEDBACK_CONTROL);
+        feedback &= 0x7f;
+        await this.i2cSlave.write8(REG_FEEDBACK_CONTROL, feedback);
 
-    // Set the full-scale voltage reference for ERM open-loop operation.
-    // 0x8C corresponds to approximately 3.02 V.
-    await this.i2cSlave.write8(REG_OVERDRIVE_CLAMP, DEFAULT_OVERDRIVE_CLAMP);
+        // ERM open-loop mode
+        let control3 = await this.i2cSlave.read8(REG_CONTROL3);
+        control3 |= 0x20;
+        await this.i2cSlave.write8(REG_CONTROL3, control3);
+      } catch (error) {
+        this.i2cSlave = null;
+        throw error;
+      }
+    })();
 
-    // Select ERM mode
-    let feedback = await this.i2cSlave.read8(REG_FEEDBACK_CONTROL);
-
-    feedback &= 0x7f;
-
-    await this.i2cSlave.write8(REG_FEEDBACK_CONTROL, feedback);
-
-    // ERM open-loop mode
-    let control3 = await this.i2cSlave.read8(REG_CONTROL3);
-
-    control3 |= 0x20;
-
-    await this.i2cSlave.write8(REG_CONTROL3, control3);
+    try {
+      await this.initPromise;
+    } finally {
+      this.initPromise = null;
+    }
   }
 
   /**
@@ -109,29 +135,50 @@ class DRV2605L {
       throw new Error("DRV2605L is not initialized");
     }
 
-    const operationId = ++this.operationId;
-
     if (!Number.isInteger(effect) || effect < 1 || effect > 123) {
       throw new RangeError("effect must be an integer from 1 to 123");
     }
 
+    const operationId = ++this.operationId;
+
     // Return to internal trigger mode
     await this.i2cSlave.write8(REG_MODE, MODE_INTERNAL_TRIGGER);
+
+    if (operationId !== this.operationId) {
+      return;
+    }
 
     // Select effect
     await this.i2cSlave.write8(REG_WAVESEQ1, effect);
 
+    if (operationId !== this.operationId) {
+      return;
+    }
+
     // End waveform sequence
     await this.i2cSlave.write8(REG_WAVESEQ2, 0x00);
+
+    if (operationId !== this.operationId) {
+      return;
+    }
 
     // Start playback
     await this.i2cSlave.write8(REG_GO, GO);
 
     // Wait until playback completes.
+    const timeout = 5000;
+    const startTime = Date.now();
+
     while ((await this.i2cSlave.read8(REG_GO)) & GO) {
       if (operationId !== this.operationId) {
         return;
       }
+
+      if (Date.now() - startTime >= timeout) {
+        await this.i2cSlave.write8(REG_GO, STOP);
+        throw new Error("DRV2605L effect playback timed out");
+      }
+
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
   }
@@ -152,7 +199,7 @@ class DRV2605L {
     }
 
     if (!Number.isInteger(duration) || duration < 0) {
-      throw new RangeError("duration must be a positive integer");
+      throw new RangeError("duration must be a non-negative integer");
     }
 
     const operationId = ++this.operationId;
@@ -160,8 +207,13 @@ class DRV2605L {
     // Change to Real-Time Playback mode
     await this.i2cSlave.write8(REG_MODE, MODE_REAL_TIME_PLAYBACK);
 
+    if (operationId !== this.operationId) {
+      return;
+    }
+
     // Start vibration
     await this.i2cSlave.write8(REG_RTP_INPUT, strength);
+
     // Keep vibrating for the specified duration
     await new Promise((resolve) => setTimeout(resolve, duration));
 

--- a/packages/drv2605l/index.js
+++ b/packages/drv2605l/index.js
@@ -4,6 +4,7 @@
 // Haptic Motor Driver
 
 const DEFAULT_SLAVE_ADDRESS = 0x5a;
+const DEFAULT_OVERDRIVE_CLAMP = 0x8c;
 
 // DRV2605L registers
 const REG_MODE = 0x01;
@@ -17,6 +18,7 @@ const REG_SUSTAIN_TIME_OFFSET_POS = 0x0e;
 const REG_SUSTAIN_TIME_OFFSET_NEG = 0x0f;
 const REG_BRAKE_TIME_OFFSET = 0x10;
 const REG_AUDIO_MAX_INPUT = 0x13;
+const REG_OVERDRIVE_CLAMP = 0x17;
 const REG_FEEDBACK_CONTROL = 0x1a;
 const REG_CONTROL3 = 0x1d;
 
@@ -34,22 +36,26 @@ class DRV2605L {
   /**
    * @constructor
    * @param {import('node-web-i2c').I2CPort} i2cPort I2C port instance
-   * @param {number?} slaveAddress I2C slave address
+   * @param {number} [slaveAddress] I2C slave address
    */
   constructor(i2cPort, slaveAddress) {
-    if (!slaveAddress) {
+    if (slaveAddress === undefined) {
       slaveAddress = DEFAULT_SLAVE_ADDRESS;
     }
 
     this.i2cPort = i2cPort;
     this.i2cSlave = null;
     this.slaveAddress = slaveAddress;
+    this.operationId = 0;
   }
 
   /**
    * Initialize DRV2605L for an ERM vibration motor.
    */
   async init() {
+    if (this.i2cSlave) {
+      return;
+    }
     this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
 
     // Internal trigger mode
@@ -76,6 +82,10 @@ class DRV2605L {
     await this.i2cSlave.write8(REG_BRAKE_TIME_OFFSET, 0x00);
 
     await this.i2cSlave.write8(REG_AUDIO_MAX_INPUT, 0x64);
+
+    // Set the full-scale voltage reference for ERM open-loop operation.
+    // 0x8C corresponds to approximately 3.02 V.
+    await this.i2cSlave.write8(REG_OVERDRIVE_CLAMP, DEFAULT_OVERDRIVE_CLAMP);
 
     // Select ERM mode
     let feedback = await this.i2cSlave.read8(REG_FEEDBACK_CONTROL);
@@ -104,6 +114,8 @@ class DRV2605L {
       throw new Error("DRV2605L is not initialized");
     }
 
+    const operationId = ++this.operationId;
+
     if (!Number.isInteger(effect) || effect < 1 || effect > 123) {
       throw new RangeError("effect must be an integer from 1 to 123");
     }
@@ -119,6 +131,14 @@ class DRV2605L {
 
     // Start playback
     await this.i2cSlave.write8(REG_GO, GO);
+
+    // Wait until playback completes.
+    while ((await this.i2cSlave.read8(REG_GO)) & GO) {
+      if (operationId !== this.operationId) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
   }
 
   /**
@@ -140,14 +160,21 @@ class DRV2605L {
       throw new RangeError("duration must be a positive integer");
     }
 
+    const operationId = ++this.operationId;
+
     // Change to Real-Time Playback mode
     await this.i2cSlave.write8(REG_MODE, MODE_REAL_TIME_PLAYBACK);
 
     // Start vibration
     await this.i2cSlave.write8(REG_RTP_INPUT, strength);
-
     // Keep vibrating for the specified duration
     await new Promise((resolve) => setTimeout(resolve, duration));
+
+    // Another operation may have started while waiting.
+    // In that case, do not overwrite its state.
+    if (operationId !== this.operationId) {
+      return;
+    }
 
     // Stop vibration
     await this.i2cSlave.write8(REG_RTP_INPUT, 0x00);
@@ -163,6 +190,8 @@ class DRV2605L {
     if (!this.i2cSlave) {
       throw new Error("DRV2605L is not initialized");
     }
+
+    this.operationId++;
 
     // Stop waveform playback
     await this.i2cSlave.write8(REG_GO, STOP);

--- a/packages/drv2605l/index.js
+++ b/packages/drv2605l/index.js
@@ -1,7 +1,8 @@
 // @ts-check
 
 // DRV2605L driver for CHIRIMEN
-// Haptic Motor Driver
+// Reference: https://www.ti.com/lit/ds/symlink/drv2605l.pdf
+// Programmed by Mutsuki Kikuchi
 
 const DEFAULT_SLAVE_ADDRESS = 0x5a;
 const DEFAULT_OVERDRIVE_CLAMP = 0x8c;

--- a/packages/drv2605l/package.json
+++ b/packages/drv2605l/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@chirimen/drv2605l",
+  "description": "Driver for DRV2605L with WebI2C",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chirimen-oh/chirimen-drivers.git",
+    "directory": "packages/drv2605l"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "exports": "./index.js",
+  "peerDependencies": {
+    "node-web-i2c": "^1.1.51"
+  }
+}


### PR DESCRIPTION
## 概要

TI製DRV2605Lハプティックモータードライバー用のWeb I2Cドライバーを追加します。

## 対応機能

- ERM振動モーターの初期化
- 内部トリガーモード
- 組み込みの波形エフェクト再生
- 強度と持続時間を設定可能なRTP振動
- 振動の停止

## テスト環境

- Raspberry Pi Zero 2 W
- DRV2605L
- ERM振動モーター
- I2Cアドレス: 0x5A

## 動作確認

- `npm link` を使用して `@chirimen/drv2605l` としてドライバーを読み込み
- Raspberry Pi Zero 2 Wでの振動を確認
- エンドツーエンドの動作を確認: Raspberry Pi Camera Module 3 Wideを使用したボトル検出 → DRV2605L → 振動モーター